### PR TITLE
Improve control of generalization and skip of simple geometry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ crashlytics-build.properties
 hs_err_pid*
 
 
+/.metadata/
+/.settings/
+/.classpath
+/.project

--- a/pom.xml
+++ b/pom.xml
@@ -8,25 +8,25 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-
+	<version>0.2</version>
+	
     <!-- set parent pom to extension pom -->
     <parent>
         <groupId>org.geoserver</groupId>
         <artifactId>extension</artifactId>
-        <version>2.7.2</version>
+          <!-- should work? () <version>[2.8.3, 3.0)</version>-->
+        <version>2.8.3</version>
     </parent>
 
     <groupId>org.geoserver.extension</groupId>
     <artifactId>gs-mvt</artifactId>
     <packaging>jar</packaging>
-    <version>2.7.2</version>
     <name>MVT WMS output format</name>
 
     <dependencies>
         <dependency>
             <groupId>org.geoserver</groupId>
             <artifactId>gs-wms</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -36,14 +36,12 @@
         <dependency>
             <groupId>org.geoserver</groupId>
             <artifactId>gs-wms</artifactId>
-            <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.geoserver</groupId>
             <artifactId>gs-main</artifactId>
-            <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/geoserver/slippymap/GeneralisationLevelEnumConverter.java
+++ b/src/main/java/org/geoserver/slippymap/GeneralisationLevelEnumConverter.java
@@ -1,0 +1,16 @@
+package org.geoserver.slippymap;
+
+import java.beans.PropertyEditorSupport;
+
+import org.geoserver.wms.GeneralisationLevel;
+
+public class GeneralisationLevelEnumConverter extends PropertyEditorSupport {
+	
+	    @Override
+	    public void setAsText(String text) throws IllegalArgumentException {
+	        String capitalized = text.toUpperCase();
+	        GeneralisationLevel generalisationLevel = GeneralisationLevel.valueOf(capitalized);
+	        setValue(generalisationLevel);
+	    }
+	
+}

--- a/src/main/java/org/geoserver/wms/GeneralisationLevel.java
+++ b/src/main/java/org/geoserver/wms/GeneralisationLevel.java
@@ -1,0 +1,16 @@
+package org.geoserver.wms;
+
+public enum GeneralisationLevel {
+	LOW("low"), MID("mid"), HIGH("high");
+
+	private String value;
+
+	GeneralisationLevel(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+}

--- a/src/main/java/org/geoserver/wms/mvt/MVTStreamingMapResponse.java
+++ b/src/main/java/org/geoserver/wms/mvt/MVTStreamingMapResponse.java
@@ -1,11 +1,18 @@
 package org.geoserver.wms.mvt;
 
+import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.geoserver.platform.Operation;
 import org.geoserver.platform.ServiceException;
+import org.geoserver.wms.GeneralisationLevel;
+import org.geoserver.wms.GetMapRequest;
 import org.geoserver.wms.map.AbstractMapResponse;
+import org.geotools.util.logging.Logging;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * The Streaming Map Response using the StreamingMVTMap for retrieving and encoding the features.
@@ -13,17 +20,90 @@ import java.io.OutputStream;
  */
 public class MVTStreamingMapResponse extends AbstractMapResponse {
 
-    public MVTStreamingMapResponse() {
+    private static final Logger LOGGER = Logging.getLogger(MVTStreamingMapResponse.class);
+    
+    public static final double DEFAULT_GENERALISATION_FACTOR = 0.1;
+	public static final String PARAM_GENERALISATION_FACTOR = "gen_factor";
+	public static final String PARAM_GENERALISATION_LEVEL = "gen_level";
+	public static final String PARAM_SKIP_SMALL_GEOMS = "skip_small_geoms";
+	
+	private GeneralisationLevel defaultGenLevel;
+	private Map<GeneralisationLevel, Map<Integer, Double>> generalisationTables;
+
+	public MVTStreamingMapResponse() {
         super(StreamingMVTMap.class, MVT.OUTPUT_FORMATS);
     }
 
     @Override
     public void write(Object value, OutputStream output, Operation operation) throws IOException, ServiceException {
-        StreamingMVTMap map = (StreamingMVTMap) value;
+    	StreamingMVTMap map = (StreamingMVTMap) value; 
+    	// if no generalisation factor / level requested from outside => use default config (factor for level mid)
+    	// use as fallback
+    	//double genFactor = getGenFactorForGenLevel(defaultGenLevel);
+    	Double genFactor = null;
+    	boolean skipSmallGeoms = true;
+    	Map<Integer, Double> genFactorTable = getGenFactorForGenLevel(defaultGenLevel); 
+    	if(operation.getParameters()[0] instanceof GetMapRequest) {
+    		// check configuration based on parameters
+    		GetMapRequest request = (GetMapRequest) operation.getParameters()[0];
+    		// if a generalisation factor is given we use it
+    		Object reqGenFactor = request.getEnv().get(PARAM_GENERALISATION_FACTOR);
+    		Object reqGenLevel = request.getEnv().get(PARAM_GENERALISATION_LEVEL);
+    	
+    		if(reqGenFactor != null && NumberUtils.isNumber((String)reqGenFactor)) {
+    			genFactor = NumberUtils.toDouble((String)reqGenFactor, DEFAULT_GENERALISATION_FACTOR);
+    		}
+    		// if no generalisation factor is given but a generalisation level is requested 
+    		// we have to look up the currently suiting generalisation
+    		else if(reqGenLevel != null) {
+    			genFactorTable = getGenFactorForRequestedLevel(reqGenLevel);
+    		}    		
+    		Object reqSkipSmallGeoms = request.getEnv().get(PARAM_SKIP_SMALL_GEOMS);
+    		if(reqSkipSmallGeoms != null) {
+    			skipSmallGeoms = BooleanUtils.toBoolean(reqSkipSmallGeoms.toString());
+    		}
+    	}
         try {
-            map.encode(output);
+        	// passed in generlalisation factor is overriding default configuration (table for zooms)
+        	if(genFactor != null) {
+        		map.encode(output, skipSmallGeoms, genFactor);
+        	}
+        	else {
+        		map.encode(output, skipSmallGeoms, genFactorTable, DEFAULT_GENERALISATION_FACTOR);
+        	}
         } finally {
             map.dispose();
         }
     }
+
+	private Map<Integer, Double> getGenFactorForGenLevel(GeneralisationLevel genLevel) {
+		return generalisationTables.get(genLevel);
+	}
+
+	private  Map<Integer, Double>  getGenFactorForRequestedLevel(Object reqGenLevel) {
+		GeneralisationLevel genLevel = GeneralisationLevel.valueOf(reqGenLevel.toString().toUpperCase());
+		if(genLevel == null) {
+			LOGGER.warning("requested generalisation level " + reqGenLevel + " is not a valid value (use \"low\", \"mid\", \"high\". "
+					+ "Default generalisation level (mid) will be used");
+			genLevel = defaultGenLevel;
+		}
+		return getGenFactorForGenLevel(genLevel);
+	}
+	
+	public GeneralisationLevel getDefaultGenLevel() {
+		return defaultGenLevel;
+	}
+
+	public void setDefaultGenLevel(GeneralisationLevel defaultGenLevel) {
+		this.defaultGenLevel = defaultGenLevel;
+	}
+	
+	public Map<GeneralisationLevel, Map<Integer, Double>> getGeneralisationTables() {
+		return generalisationTables;
+	}
+
+	public void setGeneralisationTables(
+			Map<GeneralisationLevel, Map<Integer, Double>> generalisationTables) {
+		this.generalisationTables = generalisationTables;
+	}
 }

--- a/src/main/java/org/geoserver/wms/mvt/MVTWriter.java
+++ b/src/main/java/org/geoserver/wms/mvt/MVTWriter.java
@@ -83,6 +83,27 @@ public class MVTWriter {
      * @param tileSizeX the tile size of the resulting vector tile in x direction (without buffer)
      * @param tileSizeY the tile size of the resulting vector tile in y direction (without buffer)
      * @param buffer the buffer of the vector tiles
+     * @param genFactor generalisation factor, value used as parameter in simplification algorithm
+     * @param skipSmallGeoms defines if small geometries (short linestrings or polys with small area) should be skipped in output
+     * @return an MVTWriter instance for further processing
+     *
+     * @throws FactoryException in case of the SRS is unknown
+     * @throws TransformException in case of the transformation failed
+     */
+    public static MVTWriter getInstance(Envelope sourceBBOX, CoordinateReferenceSystem sourceCRS, 
+    		int tileSizeX, int tileSizeY, int buffer, double genFactor, boolean skipSmallGeoms) throws FactoryException, TransformException {
+        Envelope targetBBOX = new ReferencedEnvelope(0,tileSizeX,0,tileSizeY,TARGET_CRS);
+        return new MVTWriter(sourceBBOX,targetBBOX,sourceCRS,buffer,genFactor, skipSmallGeoms);
+    }
+    
+    /**
+     * Retrieves an instance of the MVTWriter.
+     *
+     * @param sourceBBOX the bbox envelope requested in World coordinates
+     * @param sourceCRS the rereference system of the source bbox
+     * @param tileSizeX the tile size of the resulting vector tile in x direction (without buffer)
+     * @param tileSizeY the tile size of the resulting vector tile in y direction (without buffer)
+     * @param buffer the buffer of the vector tiles
      * @return an MVTWriter instance for further processing
      *
      * @throws FactoryException in case of the SRS is unknown
@@ -150,6 +171,15 @@ public class MVTWriter {
         return new ReferencedEnvelope(this.sourceBBOX,TARGET_CRS);
     }
 
+    private MVTWriter(Envelope sourceBBOX,
+            Envelope targetBBOX,
+            CoordinateReferenceSystem sourceCRS,
+            int bufferSize, double genFactor, boolean skipSmallGeoms) throws TransformException, FactoryException {
+		this(sourceBBOX, targetBBOX, sourceCRS, bufferSize);
+		this.vectorTileEncoder = new VectorTileEncoder(4096, targetBBOX, genFactor, skipSmallGeoms);
+	}
+
+    
     private MVTWriter(Envelope sourceBBOX,
                       Envelope targetBBOX,
                       CoordinateReferenceSystem sourceCRS,

--- a/src/main/java/org/geoserver/wms/mvt/StreamingMVTMap.java
+++ b/src/main/java/org/geoserver/wms/mvt/StreamingMVTMap.java
@@ -12,6 +12,7 @@ import org.geotools.map.Layer;
 import org.geotools.styling.FeatureTypeStyle;
 import org.geotools.styling.Rule;
 import org.geotools.styling.Style;
+import org.geotools.util.logging.Logging;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
@@ -19,12 +20,16 @@ import org.opengis.filter.spatial.BBOX;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.operation.TransformException;
 
+import com.google.common.math.LongMath;
+
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * Adapted WebMap implementation. Gets the style and retrieves filter rules. These rules are considered when loading
@@ -33,6 +38,7 @@ import java.util.Map;
  */
 public class StreamingMVTMap extends WebMap {
 
+    private static final Logger LOGGER = Logging.getLogger(StreamingMVTMap.class);
     /**
      * The Mapbox client requests 512x512 tiles but the target tile has 256 units in each direction.
      */
@@ -49,14 +55,41 @@ public class StreamingMVTMap extends WebMap {
      * Retrieves the feature from the underlying datasource and encodes them the MVT PBF format.
      *
      * @param out the outputstream to write to
+     * @param boolean skipSmallGeoms
+     * @param double genFactors
+     * @param double fallBackGen
      * @throws IOException
      */
-    public void encode(final OutputStream out) throws IOException {
+    public void encode(final OutputStream out, boolean skipSmallGeoms, 
+    		Map<Integer, Double> genFactors, double fallBackGen) throws IOException {   
+        int zoomLevel = getZoomLevel(this.mapContent.getScaleDenominator());
+        double genFactor;
+        if(zoomLevel >= 1  && zoomLevel <= 20) {
+        	genFactor = genFactors.get(zoomLevel);
+        }
+        else {
+        	genFactor = fallBackGen;
+        	LOGGER.warning("computed zoom level (" + zoomLevel + ") is out of range, using default generalisation (" + fallBackGen + ")");
+        
+        }
+        this.encode(out, skipSmallGeoms, genFactor);
+    }
+    
+    /**
+     * Retrieves the feature from the underlying datasource and encodes them the MVT PBF format.
+     *
+     * @param out the outputstream to write to
+     * @param boolean skipSmallGeoms
+     * @param double genFactor
+     * @throws IOException
+     */
+    public void encode(final OutputStream out, boolean skipSmallGeoms, double genFactor) throws IOException {
         ReferencedEnvelope renderingArea = this.mapContent.getRenderingArea();
         try {
             MVTWriter mvtWriter =
-                    MVTWriter.getInstance(renderingArea, this.mapContent.getCoordinateReferenceSystem(),
-                            targetBinaryCRSTileSize, targetBinaryCRSTileSize, this.mapContent.getBuffer());
+            		  MVTWriter.getInstance(renderingArea, this.mapContent.getCoordinateReferenceSystem(),
+                              targetBinaryCRSTileSize, targetBinaryCRSTileSize, 
+                              this.mapContent.getBuffer(), genFactor, skipSmallGeoms);
             Map<FeatureCollection,Style> featureCollectionStyleMap = new HashMap<>();
             FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
             //Iterate through all layers. Layers can be requested through WMS with comma separation
@@ -94,7 +127,14 @@ public class StreamingMVTMap extends WebMap {
         }
     }
 
-    /**
+    private int getZoomLevel(double scale) {
+    	double maxRes = 156543.03;
+		double rs = scale / (96 * 39.37);		
+		int zoom = LongMath.log2((long) (maxRes/rs), RoundingMode.HALF_UP);
+		return zoom;
+	}
+
+	/**
      * Retrieve Filter information from the Layer Style.
      * TODO maybe there is a better method to do that e.g. using a {@link org.geotools.styling.StyleVisitor}
      *

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -49,13 +49,93 @@
             </props>
         </property>
     </bean>
-
+    
     <!-- Streaming map output format -->
     <bean id="MVTStreamingMapOutputFormat" class="org.geoserver.wms.mvt.MVTStreamingMapOutputFormat">
     </bean>
 
     <!-- straming map response -->
     <bean id="MVTStreamingMapResponse" class="org.geoserver.wms.mvt.MVTStreamingMapResponse">
+    	<property name="defaultGenLevel" value="MID" />
+    	<property name="generalisationTables">
+    		<map>
+    			<entry key="LOW">
+    				<map>
+    					<entry key="0" value="0.7" />
+    					<entry key="1" value="0.7" />
+    					<entry key="2" value="0.6" />
+    					<entry key="3" value="0.6" />
+    					<entry key="4" value="0.6" />
+    					<entry key="5" value="0.6" />
+    					<entry key="6" value="0.6" />
+    					<entry key="7" value="0.6" />
+    					<entry key="8" value="0.6" />
+    					<entry key="9" value="0.5" />
+    					<entry key="10" value="0.4" />
+    					<entry key="11" value="0.35" />
+    					<entry key="12" value="0.3" />
+    					<entry key="13" value="0.25" />
+    					<entry key="14" value="0.2" />
+    					<entry key="15" value="0.15" />
+    					<entry key="16" value="0.1" />
+    					<entry key="17" value="0.05" />
+    					<entry key="18" value="0.01" />
+    					<entry key="19" value="0.005" />
+    					<entry key="20" value="0.001" />
+    				</map>
+    			</entry>	
+    			<entry key="MID">
+    				<map>
+    					<entry key="0" value="0.8" />
+    					<entry key="1" value="0.8" />
+    					<entry key="2" value="0.8" />
+    					<entry key="3" value="0.7" />
+    					<entry key="4" value="0.7" />
+    					<entry key="5" value="0.7" />
+    					<entry key="6" value="0.7" />
+    					<entry key="7" value="0.7" />
+    					<entry key="8" value="0.7" />
+    					<entry key="9" value="0.6" />
+    					<entry key="10" value="0.5" />
+    					<entry key="11" value="0.45" />
+    					<entry key="12" value="0.4" />
+    					<entry key="13" value="0.35" />
+    					<entry key="14" value="0.3" />
+    					<entry key="15" value="0.25" />
+    					<entry key="16" value="0.2" />
+    					<entry key="17" value="0.1" />
+    					<entry key="18" value="0.05" />
+    					<entry key="19" value="0.025" />
+    					<entry key="20" value="0.01" />
+    				</map>
+    			</entry>	
+    			<entry key="HIGH">
+    				<map>
+    					<entry key="0" value="1.0" />
+    					<entry key="1" value="1.0" />
+    					<entry key="2" value="1.0" />
+    					<entry key="3" value="1.0" />
+    					<entry key="4" value="1.0" />
+    					<entry key="5" value="1.0" />
+    					<entry key="6" value="1.0" />
+    					<entry key="7" value="0.9" />
+    					<entry key="8" value="0.9" />
+    					<entry key="9" value="0.8" />
+    					<entry key="10" value="0.7" />
+    					<entry key="11" value="0.7" />
+    					<entry key="12" value="0.7" />
+    					<entry key="13" value="0.6" />
+    					<entry key="14" value="0.5" />
+    					<entry key="15" value="0.4" />
+    					<entry key="16" value="0.3" />
+    					<entry key="17" value="0.2" />
+    					<entry key="18" value="0.1" />
+    					<entry key="19" value="0.05" />
+    					<entry key="20" value="0.01" />
+    				</map>
+    			</entry>	
+    		</map>
+    	</property>
     </bean>
   
 </beans>

--- a/src/test/java/org/geoserver/AbstractMVTTest.java
+++ b/src/test/java/org/geoserver/AbstractMVTTest.java
@@ -1,0 +1,34 @@
+package org.geoserver;
+
+import java.util.Collections;
+
+import javax.xml.namespace.QName;
+
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.wms.WMSTestSupport;
+import org.geoserver.wms.mvt.MVTTest;
+
+public class AbstractMVTTest extends WMSTestSupport {
+
+	public static QName TEST_LINES = new QName(MockData.CITE_URI, "test_lines",
+			MockData.CITE_PREFIX);
+	public static QName TEST_POINTS = new QName(MockData.CITE_URI,
+			"test_points", MockData.CITE_PREFIX);
+	public static QName TEST_POLYGONS = new QName(MockData.CITE_URI,
+			"test_polygons", MockData.CITE_PREFIX);
+	public static String STYLE_NAME = "test_pbf_filter";
+
+	@Override
+	protected void onSetUp(SystemTestData testData) throws Exception {
+		super.onSetUp(testData);
+		testData.addStyle(STYLE_NAME, "./test_pbf_filter.sld", getClass(),
+				getCatalog());
+		testData.addVectorLayer(TEST_LINES, Collections.EMPTY_MAP,
+				"test_lines.properties", MVTTest.class, getCatalog());
+		testData.addVectorLayer(TEST_POINTS, Collections.EMPTY_MAP,
+				"test_points.properties", MVTTest.class, getCatalog());
+		testData.addVectorLayer(TEST_POLYGONS, Collections.EMPTY_MAP,
+				"test_polygons.properties", MVTTest.class, getCatalog());
+	}
+}

--- a/src/test/java/org/geoserver/wms/mvt/SlippyTilesControllerTest.java
+++ b/src/test/java/org/geoserver/wms/mvt/SlippyTilesControllerTest.java
@@ -1,0 +1,40 @@
+package org.geoserver.wms.mvt;
+
+import org.geoserver.AbstractMVTTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.mockrunner.mock.web.MockHttpServletResponse;
+
+/**
+ *
+ * Test for access to slippy map controller
+ *
+ */
+public class SlippyTilesControllerTest extends AbstractMVTTest {
+
+    @Test
+    public void testRequestParams() throws Exception {
+    	
+    	String requestSlippy = "slippymap/" + TEST_LINES.getPrefix() + ":" + TEST_LINES.getLocalPart() + "/12/2196/1427.pbf" +
+    			"?buffer=10&styles=" + STYLE_NAME + "&tileSize=256&gen_level=low";    	
+        MockHttpServletResponse responseSlippy = getAsServletResponse(requestSlippy);
+        Assert.assertEquals(200, responseSlippy.getStatusCode());
+        
+/*      test if content is the same when requested via slippy map or wms (tile is same then bbox). 
+ * 		Unfortunately it seems that the forward in slippymap Controller is not executed correctly in Moc environment.
+ * 		Response is ok (200) but content is empty, debugging shows that no breakpoint in MVT Plugin is hit in case of slippy map request 
+ * 
+   		String requestWms = "wms?request=getmap&service=wms&version=1.1.1" +
+                "&format=" + MVT.MIME_TYPE +
+                "&layers=" + TEST_LINES.getPrefix() + ":" + TEST_LINES.getLocalPart() +
+                "&styles=" + STYLE_NAME + 
+                "&height=256&width=256&bbox=1448023.063834379,6066042.5647115875,1457807.0034548815,6075826.50433209&srs=EPSG:3857&buffer=10";
+        MockHttpServletResponse responseWms = getAsServletResponse(requestWms);
+
+        byte[] contentSlippy = responseSlippy.getOutputStreamContent().getBytes();
+        byte[] contentWms = responseWms.getOutputStreamContent().getBytes();
+        Assert.assertEquals(contentSlippy.length, contentWms.length);*/
+    }
+    
+}


### PR DESCRIPTION
Added generalisation factor as URL Parameter of Slippy Map or ENV Param in WMS
Added generalisation levels (predefined generalisation per Zoom)
Added URL Parameter of Slippy Map or ENV Param in WMS to enable/disable
skipping of small geometries (lines/areas)
